### PR TITLE
Simplify and update evaluation code

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ WhisperKit currently only supports Qualcomm AI Hub Whisper models on Hugging Fac
 whisperkittools generates 3 more support models for input preprocessing and output postprocessing used in the WhisperKitAndroid pipeline. These are all published on Hugging Face [here](https://huggingface.co/argmaxinc/whisperkit-android/tree/main). Nonetheless, you may regenerate these models if you wish by following these steps:
 - **Step 1**: Create an account at [aihub.qualcomm.com](aihub.qualcomm.com)
 - **Step 2**: Set your API key locally as `qai-hub configure --api_token`
-- **Step 3**: Install extra dependencies via `pip install '.[android]'` (Note that this requires `python<3.11`)
+- **Step 3**: Install extra dependencies via `pip install -e '.[android]'` (Note that this requires `python<3.11`)
 - **Step 4**: Execute `python tests/test_aihub.py --persistent-cache-dir <output-path>`
 
 Stay tuned for more options for generating models without creating an account and more model version coverage!
@@ -91,7 +91,7 @@ whisperkit-evaluate-model --model-version <model-version> --output-dir <output-d
 
 Install additional dependencies via:
 ```shell
-pip install '.[evals]'
+pip install -e '.[evals,pipelines]'
 ```
 
 By default, this command uses the latest `main` branch commits from `WhisperKit` and searches within [Argmax-published](https://huggingface.co/argmaxinc/whisperkit-coreml) model repositories. For optional arguments related to code and model versioning, please see the help menu with `-h`
@@ -120,7 +120,7 @@ Use the unified Python wrapper for several on-device Whisper frameworks:
 
 Install additional dependencies via:
 ```shell
-pip install '.[pipelines]'
+pip install -e '.[pipelines]'
 ```
 
 ```python

--- a/setup.py
+++ b/setup.py
@@ -17,15 +17,13 @@ setup(
         "argmaxtools",
         "transformers",
         "huggingface-hub",
-        "tabulate",
     ],
     extras_require={
         "pipelines": [
             "openai",
-            "mlx",
+            "mlx-whisper",
         ],
         "evals": [
-            "mlx",
             "jiwer",
             "soundfile",
             "librosa",

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -90,6 +90,7 @@ class TestWhisperPipelineEvaluate(unittest.TestCase):
         out_path = os.path.join(TEST_CACHE_DIR, "results.json")
         with open(out_path, "w") as f:
             json.dump(cls.results, f, indent=2)
+        logger.info(f"Saved results to {out_path}")
 
         if TEST_UPLOAD_RESULTS:
             results_dir = os.path.join(
@@ -101,6 +102,7 @@ class TestWhisperPipelineEvaluate(unittest.TestCase):
                 ).strftime("%Y-%m-%d_%H:%M:%S_GMT%z") + ".json"
 
             api = HfApi()
+            logger.info(f"Uploading results to hf.co/datasets/{EVALS_REPO_ID}")
             api.upload_file(
                 path_or_fileobj=out_path,
                 path_in_repo=os.path.join(results_dir, results_fname),
@@ -110,11 +112,8 @@ class TestWhisperPipelineEvaluate(unittest.TestCase):
                                f"Eval {TEST_MODEL_VERSION} on {TEST_DATASET_NAME}",
             )
         else:
-            logger.info(
-                f"Skipped uploading results to hf.co/datasets/{EVALS_REPO_ID} "
-                "because dataset was not fully evaluated (--num-samples)"
-            )
-            pprint.pprint(cls.results)
+            logger.info(f"Skipped uploading results to hf.co/datasets/{EVALS_REPO_ID} ")
+            # pprint.pprint(cls.results)
 
     def test_evaluate(self):
         pass

--- a/whisperkit/evaluate/evaluate.py
+++ b/whisperkit/evaluate/evaluate.py
@@ -38,7 +38,7 @@ def evaluate(whisper_pipeline: Union[pipelines.WhisperPipeline, pipelines.Whispe
     begin = time.time()
 
     # Warm-up (model compilation without multi-processing)
-    logger.info("Warmup the pipeline using the first sample (discard the result)")
+    logger.info("Warmup the pipeline on a single sample (may trigger model download)")
     _ = evaluate_sample(dataset[0], whisper_pipeline)
 
     if num_proc > len(dataset):

--- a/whisperkit/test_utils.py
+++ b/whisperkit/test_utils.py
@@ -14,12 +14,6 @@ from argmaxtools.test_utils import (AppleSiliconContextMixin,
 from transformers.models.whisper import modeling_whisper
 
 
-class CoreMLSwiftComputeUnit(Enum):
-    ANE = "cpuAndNeuralEngine"
-    CPU = "cpuOnly"
-    GPU = "cpuAndGPU"
-
-
 class BenchmarkContext(AppleSiliconContextMixin, InferenceContextSpec):
     """ Context specifier to reproduce an inference context
     """


### PR DESCRIPTION
- [x] Adopt `mlx-whisper` from PyPI and remove repo+model cloning
- [x] Adopt configs and arguments for `WhisperMLX` and `WhisperCpp` to represent apples-to-apples performance and quality.
- [x] Allow for dead simple evaluations

e.g.

```shell
pip install -e `.[evals,pipelines]` &&  whisperkit-evaluate-model --model-version openai/whisper-tiny.en --evaluation-dataset earnings22-debug --pipeline {whisper.cpp,WhisperMLX,WhisperKit} --output-dir evals
```