### PR TITLE
Disable token timestamps for distilled models detected by config, not name

### DIFF
--- a/scripts/generate_model.py
+++ b/scripts/generate_model.py
@@ -133,6 +133,29 @@ def cli():
             "Disabling token-level timestamps due to missing alignment_heads in distil-whisper-* models"
         )
         args.disable_token_timestamps = True
+    else:
+        # Some distilled models are not named "distil-*" yet still carry the
+        # original (e.g. large-v3) generation_config, whose alignment_heads
+        # reference decoder layers that no longer exist after distillation.
+        # Configuring token-level timestamps then crashes with an IndexError in
+        # compute_alignment_heads_attention_weights. Detect this from the config
+        # (rather than the model name) and disable token timestamps.
+        try:
+            from transformers import GenerationConfig, WhisperConfig
+            decoder_layers = WhisperConfig.from_pretrained(
+                args.model_version).decoder_layers
+            alignment_heads = getattr(
+                GenerationConfig.from_pretrained(args.model_version),
+                "alignment_heads", None,
+            ) or []
+            if any(layer >= decoder_layers for layer, _head in alignment_heads):
+                logger.info(
+                    "Disabling token-level timestamps: alignment_heads reference "
+                    f"decoder layers beyond decoder_layers={decoder_layers}"
+                )
+                args.disable_token_timestamps = True
+        except Exception as e:
+            logger.warning(f"alignment_heads validation skipped: {e}")
 
     # Generate WhisperTextDecoder
     args.test_seq_len = args.text_decoder_max_sequence_length


### PR DESCRIPTION
## Problem

`scripts/generate_model.py` only disables token-level timestamps for models whose version string contains `distil`. Some distilled models are **not** named `distil-*` yet still ship the original (e.g. `large-v3`) `generation_config`, whose `alignment_heads` reference decoder layers that no longer exist after distillation. Generating token timestamps then crashes with an `IndexError` in `compute_alignment_heads_attention_weights`.

**Repro:** `whisperkit-generate-model --model-version kotoba-tech/kotoba-whisper-bilingual-v1.0` — the model has 2 decoder layers but ships large-v3 `alignment_heads` up to layer 25; the WhisperTextDecoder step fails.

## Fix

In addition to the existing name-based check, detect the condition from the config: if any `alignment_heads` entry references a layer `>= decoder_layers`, disable token timestamps. Falls back gracefully (warns and continues) if the config can't be read.

## Evidence

This change was applied when converting `kotoba-tech/kotoba-whisper-bilingual-v1.0` (whisperkittools 0.4.2, coremltools 9.0, torch 2.5.0). With it, the guard fires and the conversion completes:

```
INFO:scripts.generate_model:Disabling token-level timestamps: alignment_heads reference decoder layers beyond decoder_layers=2
INFO:argmaxtools.test_utils:torch2coreml PSNR=57.4   # TextDecoder
INFO:argmaxtools.test_utils:torch2coreml PSNR=53.9   # AudioEncoder
INFO:argmaxtools.test_utils:torch2coreml PSNR=59.8   # MelSpectrogram
```

Without the change the same run fails at the decoder step with the IndexError above. I have not re-run the full suite against other models; the change only widens an existing disable condition and is a no-op for models without oversized `alignment_heads`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)